### PR TITLE
Update public API to support starting a VNC session on an externally defined Socket

### DIFF
--- a/src/main/java/com/shinyhut/vernacular/client/VernacularClient.java
+++ b/src/main/java/com/shinyhut/vernacular/client/VernacularClient.java
@@ -47,8 +47,18 @@ public class VernacularClient {
      * @param port Remote port to connect to
      * @throws IllegalStateException if the client is already running
      */
-    public void start(String host, int port) {
+    public void start(String host, int port) throws IOException {
+        startSocket(new Socket(host, port));
+    }
 
+
+    /**
+     * Starts the VNC client by connecting to the specified socket
+     *
+     * @param socket Socket to connect to
+     * @throws IllegalStateException if the client is already running
+     */
+    public void startSocket(Socket socket) {
         if (running) {
             throw new IllegalStateException("VNC Client is already running");
         }
@@ -56,7 +66,7 @@ public class VernacularClient {
         running = true;
 
         try {
-            createSession(host, port);
+            createSession(socket);
             clientEventHandler = new ClientEventHandler(session, this::handleError);
             serverEventHandler = new ServerEventHandler(session, this::handleError);
 
@@ -67,7 +77,6 @@ public class VernacularClient {
         } catch (VncException e) {
             handleError(e);
         }
-
     }
 
     /**
@@ -259,8 +268,7 @@ public class VernacularClient {
         return running;
     }
 
-    private void createSession(String host, int port) throws IOException, VncException {
-        Socket socket = new Socket(host, port);
+    private void createSession(Socket socket) throws IOException, VncException {
         InputStream in = new BufferedInputStream(socket.getInputStream());
         OutputStream out = socket.getOutputStream();
         session = new VncSession(config, in, out);

--- a/src/main/java/com/shinyhut/vernacular/client/VernacularClient.java
+++ b/src/main/java/com/shinyhut/vernacular/client/VernacularClient.java
@@ -47,10 +47,13 @@ public class VernacularClient {
      * @param port Remote port to connect to
      * @throws IllegalStateException if the client is already running
      */
-    public void start(String host, int port) throws IOException {
-        startSocket(new Socket(host, port));
+    public void start(String host, int port) {
+        try {
+            start(new Socket(host, port));
+        } catch (IOException e) {
+            handleError(new UnexpectedVncException(e));
+        }
     }
-
 
     /**
      * Starts the VNC client by connecting to the specified socket
@@ -58,7 +61,7 @@ public class VernacularClient {
      * @param socket Socket to connect to
      * @throws IllegalStateException if the client is already running
      */
-    public void startSocket(Socket socket) {
+    public void start(Socket socket) {
         if (running) {
             throw new IllegalStateException("VNC Client is already running");
         }


### PR DESCRIPTION
This will make the VNC connection method more flexible by having a startSocket() which enable the client to pass vnc socket too. This would be very helpful to deal with the unix socket.