### PR TITLE
Fix 16 bits per pixel colordepth, remove ProtocolVersion validation and new functionality to choose the server color preference.

### DIFF
--- a/src/main/java/com/shinyhut/vernacular/VernacularViewer.java
+++ b/src/main/java/com/shinyhut/vernacular/VernacularViewer.java
@@ -39,6 +39,7 @@ public class VernacularViewer extends JFrame {
     private JMenuItem bpp8IndexedColorMenuItem;
     private JMenuItem bpp16TrueColorMenuItem;
     private JMenuItem bpp24TrueColorMenuItem;
+    private JMenuItem serverColorPreferenceMenuItem;
     private JMenuItem localCursorMenuItem;
 
     private JMenu encodingsMenu;
@@ -248,13 +249,17 @@ public class VernacularViewer extends JFrame {
         bpp8IndexedColorMenuItem = new JRadioButtonMenuItem("8-bit Indexed Color");
         bpp16TrueColorMenuItem = new JRadioButtonMenuItem("16-bit True Color", true);
         bpp24TrueColorMenuItem = new JRadioButtonMenuItem("24-bit True Color");
+        serverColorPreferenceMenuItem = new JRadioButtonMenuItem("Server color preference");
+
         colorDepths.add(bpp8IndexedColorMenuItem);
         colorDepths.add(bpp16TrueColorMenuItem);
         colorDepths.add(bpp24TrueColorMenuItem);
+        colorDepths.add(serverColorPreferenceMenuItem);
 
         bpp8IndexedColorMenuItem.addActionListener(event -> config.setColorDepth(BPP_8_INDEXED));
         bpp16TrueColorMenuItem.addActionListener(event -> config.setColorDepth(BPP_16_TRUE));
         bpp24TrueColorMenuItem.addActionListener(event -> config.setColorDepth(BPP_24_TRUE));
+        serverColorPreferenceMenuItem.addActionListener(event -> config.setServerPreference(true));
 
         localCursorMenuItem = new JCheckBoxMenuItem("Use Local Cursor", true);
         localCursorMenuItem.addActionListener(event -> config.setUseLocalMousePointer(localCursorMenuItem.isSelected()));

--- a/src/main/java/com/shinyhut/vernacular/client/VernacularConfig.java
+++ b/src/main/java/com/shinyhut/vernacular/client/VernacularConfig.java
@@ -20,6 +20,7 @@ public class VernacularConfig {
     private Consumer<String> remoteClipboardListener;
     private BiConsumer<Image, Point> mousePointerUpdateListener;
     private boolean shared = true;
+    private boolean serverPreference = false;
     private int targetFramesPerSecond = 30;
     private ColorDepth colorDepth = BPP_8_INDEXED;
     private boolean useLocalMousePointer = false;
@@ -240,5 +241,21 @@ public class VernacularConfig {
      */
     public void setEnableZLibEncoding(boolean enableZLibEncoding) {
         this.enableZLibEncoding = enableZLibEncoding;
+    }
+
+    public boolean isServerPreference() {
+        return serverPreference;
+    }
+
+    /**
+     * Specifies whether we should use the pixel format from the remote server. It is exchanged during the initialization
+     * <p>
+     * If this is set to false, client uses a defined ColorDepth option
+     * <p>
+     *
+     * @param serverPreference Should we use the pixel format from the remote server.
+     */
+    public void setServerPreference(boolean serverPreference) {
+        this.serverPreference = serverPreference;
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/client/rendering/ColorDepth.java
+++ b/src/main/java/com/shinyhut/vernacular/client/rendering/ColorDepth.java
@@ -9,7 +9,7 @@ public enum ColorDepth {
     BPP_8_TRUE(8, 8, true, 7, 3, 7, 0, 6, 3),
 
     /** 16 bits per pixel true color **/
-    BPP_16_TRUE(16, 16, true, 31, 63, 31, 11, 5, 0),
+    BPP_16_TRUE(16, 16, true, 31, 31, 63, 11, 0, 5),
 
     /** 24 bits per pixel true color **/
     BPP_24_TRUE(32, 24, true, 255, 255, 255, 8, 24, 16);

--- a/src/main/java/com/shinyhut/vernacular/protocol/handshaking/ProtocolVersionNegotiator.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/handshaking/ProtocolVersionNegotiator.java
@@ -1,13 +1,9 @@
 package com.shinyhut.vernacular.protocol.handshaking;
 
 import com.shinyhut.vernacular.client.VncSession;
-import com.shinyhut.vernacular.client.exceptions.UnsupportedProtocolVersionException;
-import com.shinyhut.vernacular.client.exceptions.VncException;
 import com.shinyhut.vernacular.protocol.messages.ProtocolVersion;
 
 import java.io.IOException;
-
-import static java.lang.Math.min;
 
 public class ProtocolVersionNegotiator {
 
@@ -15,21 +11,10 @@ public class ProtocolVersionNegotiator {
     private static final int MIN_MINOR_VERSION = 3;
     private static final int MAX_MINOR_VERSION = 8;
 
-    public void negotiate(VncSession session) throws IOException, VncException {
-        ProtocolVersion serverVersion = ProtocolVersion.decode(session.getInputStream());
-
-        if (!serverVersion.atLeast(MAJOR_VERSION, MIN_MINOR_VERSION)) {
-            throw new UnsupportedProtocolVersionException(
-                    serverVersion.getMajor(),
-                    serverVersion.getMinor(),
-                    MAJOR_VERSION,
-                    MIN_MINOR_VERSION
-            );
-        }
-
+    public void negotiate(VncSession session) throws IOException {
         ProtocolVersion clientVersion = new ProtocolVersion(
                 MAJOR_VERSION,
-                min(serverVersion.getMinor(), MAX_MINOR_VERSION)
+                MAX_MINOR_VERSION
         );
 
         session.setProtocolVersion(clientVersion);

--- a/src/main/java/com/shinyhut/vernacular/protocol/initialization/Initializer.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/initialization/Initializer.java
@@ -29,17 +29,20 @@ public class Initializer {
         VernacularConfig config = session.getConfig();
         ColorDepth colorDepth = config.getColorDepth();
 
-        PixelFormat pixelFormat = new PixelFormat(
-                colorDepth.getBitsPerPixel(),
-                colorDepth.getDepth(),
-                true,
-                colorDepth.isTrueColor(),
-                colorDepth.getRedMax(),
-                colorDepth.getGreenMax(),
-                colorDepth.getBlueMax(),
-                colorDepth.getRedShift(),
-                colorDepth.getGreenShift(),
-                colorDepth.getBlueShift());
+        PixelFormat serverPixelFormat = serverInit.getPixelFormat();
+        PixelFormat pixelFormat = config.isServerPreference() ? new PixelFormat(serverPixelFormat) :
+                new PixelFormat(
+                        colorDepth.getBitsPerPixel(),
+                        colorDepth.getDepth(),
+                        true,
+                        colorDepth.isTrueColor(),
+                        colorDepth.getRedMax(),
+                        colorDepth.getGreenMax(),
+                        colorDepth.getBlueMax(),
+                        colorDepth.getRedShift(),
+                        colorDepth.getGreenShift(),
+                        colorDepth.getBlueShift());
+
 
         SetPixelFormat setPixelFormat = new SetPixelFormat(pixelFormat);
 

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/PixelFormat.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/PixelFormat.java
@@ -29,6 +29,19 @@ public class PixelFormat implements Encodable {
         this.blueShift = blueShift;
     }
 
+    public PixelFormat(PixelFormat serverPixelFormat) {
+        this.bitsPerPixel = serverPixelFormat.getBitsPerPixel();
+        this.depth = serverPixelFormat.getDepth();
+        this.bigEndian = true;
+        this.trueColor = serverPixelFormat.isTrueColor();
+        this.redMax = serverPixelFormat.getRedMax();
+        this.greenMax = serverPixelFormat.getGreenMax();
+        this.blueMax = serverPixelFormat.getBlueMax();
+        this.redShift = serverPixelFormat.getRedShift();
+        this.greenShift = serverPixelFormat.getGreenShift();
+        this.blueShift = serverPixelFormat.getBlueShift();
+    }
+
     public int getBitsPerPixel() {
         return bitsPerPixel;
     }


### PR DESCRIPTION
1. Fix incorrect 16 bits per pixel configuration

Fix incorrect 16 bits per pixel configuration. It breaks some negotiation with VNC servers and the server returns a TCP reset.


2. Remove ProtocolVersionNegotiator validation

Remove ProtocolVersionNegotiator validation. It blocks the connection with proprietary manufacturers with version 4.0 such us Intel AMT

3. Included new functionality to use the server color preference