### PR TITLE
Implemented extended clipboard support

### DIFF
--- a/src/main/java/com/shinyhut/vernacular/client/ClientEventHandler.java
+++ b/src/main/java/com/shinyhut/vernacular/client/ClientEventHandler.java
@@ -2,7 +2,13 @@ package com.shinyhut.vernacular.client;
 
 import com.shinyhut.vernacular.client.exceptions.UnexpectedVncException;
 import com.shinyhut.vernacular.client.exceptions.VncException;
-import com.shinyhut.vernacular.protocol.messages.*;
+import com.shinyhut.vernacular.protocol.messages.ClientCutText;
+import com.shinyhut.vernacular.protocol.messages.ClientCutTextCaps;
+import com.shinyhut.vernacular.protocol.messages.ClientCutTextExtendedClipboard;
+import com.shinyhut.vernacular.protocol.messages.Encodable;
+import com.shinyhut.vernacular.protocol.messages.FramebufferUpdateRequest;
+import com.shinyhut.vernacular.protocol.messages.KeyEvent;
+import com.shinyhut.vernacular.protocol.messages.PointerEvent;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -92,9 +98,21 @@ public class ClientEventHandler {
         sendMessage(message);
     }
 
+    void sendClientCutTextCaps() throws IOException {
+        ClientCutTextCaps clientCutTextCaps = new ClientCutTextCaps(session.getConfig().getMaxSizePerFormat());
+        sendMessage(clientCutTextCaps);
+    }
+
     void copyText(String text) throws IOException {
-        ClientCutText message = new ClientCutText(text);
-        sendMessage(message);
+        if (session.getConfig().isEnableExtendedClipboard()) {
+            sendClientCutTextCaps();
+
+            ClientCutTextExtendedClipboard clientCutTextExtendedClipboard = new ClientCutTextExtendedClipboard(text);
+            sendMessage(clientCutTextExtendedClipboard);
+        } else {
+            ClientCutText message = new ClientCutText(text);
+            sendMessage(message);
+        }
     }
 
     private void updateMouseStatus() throws IOException {

--- a/src/main/java/com/shinyhut/vernacular/client/ServerEventHandler.java
+++ b/src/main/java/com/shinyhut/vernacular/client/ServerEventHandler.java
@@ -58,7 +58,7 @@ public class ServerEventHandler {
                         case 0x03:
                             ServerCutText cutText = ServerCutText.decode(in);
                             Consumer<String> cutTextListener = session.getConfig().getRemoteClipboardListener();
-                            if (cutTextListener != null) {
+                            if (cutTextListener != null && !cutText.getText().isEmpty()) {
                                 cutTextListener.accept(cutText.getText());
                             }
                             break;

--- a/src/main/java/com/shinyhut/vernacular/client/VernacularConfig.java
+++ b/src/main/java/com/shinyhut/vernacular/client/VernacularConfig.java
@@ -2,8 +2,11 @@ package com.shinyhut.vernacular.client;
 
 import com.shinyhut.vernacular.client.exceptions.VncException;
 import com.shinyhut.vernacular.client.rendering.ColorDepth;
+import com.shinyhut.vernacular.protocol.messages.MessageHeaderFlags;
 
 import java.awt.*;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -24,9 +27,12 @@ public class VernacularConfig {
     private ColorDepth colorDepth = BPP_8_INDEXED;
     private boolean useLocalMousePointer = false;
     private boolean enableCopyrectEncoding = true;
+    private boolean enableExtendedClipboard = true;
     private boolean enableRreEncoding = true;
     private boolean enableHextileEncoding = true;
     private boolean enableZLibEncoding = false;
+
+    private Map<MessageHeaderFlags, Integer> maxSizePerFormat = new EnumMap<>(MessageHeaderFlags.class);
 
     public Supplier<String> getUsernameSupplier() {
         return usernameSupplier;
@@ -197,6 +203,10 @@ public class VernacularConfig {
         return enableCopyrectEncoding;
     }
 
+    public boolean isEnableExtendedClipboard() {
+        return enableExtendedClipboard;
+    }
+
     /**
      * Enable or disable the COPYRECT video encoding
      * @param enableCopyrectEncoding enable or disable the COPYRECT video encoding
@@ -240,5 +250,9 @@ public class VernacularConfig {
      */
     public void setEnableZLibEncoding(boolean enableZLibEncoding) {
         this.enableZLibEncoding = enableZLibEncoding;
+    }
+
+    public Map<MessageHeaderFlags, Integer> getMaxSizePerFormat() {
+        return maxSizePerFormat;
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/initialization/Initializer.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/initialization/Initializer.java
@@ -3,15 +3,26 @@ package com.shinyhut.vernacular.protocol.initialization;
 import com.shinyhut.vernacular.client.VernacularConfig;
 import com.shinyhut.vernacular.client.VncSession;
 import com.shinyhut.vernacular.client.rendering.ColorDepth;
-import com.shinyhut.vernacular.protocol.messages.*;
+import com.shinyhut.vernacular.protocol.messages.ClientInit;
+import com.shinyhut.vernacular.protocol.messages.Encoding;
+import com.shinyhut.vernacular.protocol.messages.PixelFormat;
+import com.shinyhut.vernacular.protocol.messages.ServerInit;
+import com.shinyhut.vernacular.protocol.messages.SetEncodings;
+import com.shinyhut.vernacular.protocol.messages.SetPixelFormat;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.shinyhut.vernacular.protocol.messages.Encoding.*;
-import static java.util.Arrays.asList;
+import static com.shinyhut.vernacular.protocol.messages.Encoding.COPYRECT;
+import static com.shinyhut.vernacular.protocol.messages.Encoding.CURSOR;
+import static com.shinyhut.vernacular.protocol.messages.Encoding.DESKTOP_SIZE;
+import static com.shinyhut.vernacular.protocol.messages.Encoding.EXTENDED_CLIPBOARD;
+import static com.shinyhut.vernacular.protocol.messages.Encoding.HEXTILE;
+import static com.shinyhut.vernacular.protocol.messages.Encoding.RAW;
+import static com.shinyhut.vernacular.protocol.messages.Encoding.RRE;
+import static com.shinyhut.vernacular.protocol.messages.Encoding.ZLIB;
 
 public class Initializer {
 
@@ -59,6 +70,10 @@ public class Initializer {
 
         if (config.isEnableCopyrectEncoding()) {
             encodings.add(COPYRECT);
+        }
+
+        if (config.isEnableExtendedClipboard()) {
+            encodings.add(EXTENDED_CLIPBOARD);
         }
 
         encodings.add(RAW);

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/ClientCutTextCaps.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/ClientCutTextCaps.java
@@ -1,0 +1,43 @@
+package com.shinyhut.vernacular.protocol.messages;
+
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+public class ClientCutTextCaps  implements Encodable {
+
+    private final Map<MessageHeaderFlags, Integer> sizes;
+
+    public ClientCutTextCaps(Map<MessageHeaderFlags, Integer> sizes) {
+        this.sizes = sizes;
+    }
+
+    @Override
+    public void encode(OutputStream out) throws IOException {
+        int[] flags = new int[]{ MessageHeaderFlags.CAPS.code
+                | MessageHeaderFlags.NOTIFY.code | MessageHeaderFlags.PEEK.code
+                | MessageHeaderFlags.PROVIDE.code
+                | MessageHeaderFlags.REQUEST.code
+        };
+
+        byte[] formatSizes = new byte[sizes.size() * 4];
+        sizes.forEach((format, size) -> {
+            flags[0] = flags[0] | format.code;
+            int startByte = format.ordinal();
+            byte[] sizeForCurrentFormat = ByteBuffer.allocate(4).putInt(size).array();
+            System.arraycopy(sizeForCurrentFormat, 0, formatSizes, startByte, 4);
+        });
+
+        DataOutput dataOutput = new DataOutputStream(out);
+
+        dataOutput.writeByte(0x06);
+        dataOutput.write(new byte[3]);
+
+        dataOutput.writeInt(formatSizes.length + 4);
+        dataOutput.writeInt(flags[0]);
+        dataOutput.write(formatSizes);
+    }
+}

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/ClientCutTextExtendedClipboard.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/ClientCutTextExtendedClipboard.java
@@ -1,0 +1,57 @@
+package com.shinyhut.vernacular.protocol.messages;
+
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.zip.Deflater;
+
+import static com.shinyhut.vernacular.protocol.messages.MessageHeaderFlags.PROVIDE;
+import static com.shinyhut.vernacular.protocol.messages.MessageHeaderFlags.TEXT;
+
+public class ClientCutTextExtendedClipboard  implements Encodable {
+
+    private final String text;
+
+    public ClientCutTextExtendedClipboard(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public void encode(OutputStream out) throws IOException {
+        int flags = PROVIDE.code | TEXT.code;
+
+        byte[] textBytes = text.getBytes(StandardCharsets.UTF_8);
+        byte[] testLengthInBytes = ByteBuffer.allocate(4).putInt(textBytes.length + 1).array();
+        byte[] input = new byte[4 + textBytes.length + 1];
+
+        System.arraycopy(testLengthInBytes, 0, input, 0, testLengthInBytes.length);
+        System.arraycopy(textBytes, 0, input, testLengthInBytes.length, textBytes.length);
+
+        byte[] output = new byte[20 * 1024 * 1024];
+
+        Deflater compresser = new Deflater();
+        compresser.setInput(input);
+        compresser.finish();
+        int compressedDataLength = compresser.deflate(output);
+
+        DataOutput dataOutput = new DataOutputStream(out);
+
+        dataOutput.writeByte(0x06);
+        dataOutput.write(new byte[3]);
+
+        dataOutput.writeInt(-(compressedDataLength + 4));
+        dataOutput.writeInt(flags);
+
+        byte[] result = Arrays.copyOfRange(output, 0, compressedDataLength);
+
+        dataOutput.write(result);
+    }
+}

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/Encoding.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/Encoding.java
@@ -12,7 +12,8 @@ public enum Encoding {
     HEXTILE(5),
     ZLIB(6),
     DESKTOP_SIZE(-223),
-    CURSOR(-239)
+    CURSOR(-239),
+    EXTENDED_CLIPBOARD(0xC0A1E5CE)
     ;
 
     private int code;

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/MessageHeaderFlags.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/MessageHeaderFlags.java
@@ -1,0 +1,21 @@
+package com.shinyhut.vernacular.protocol.messages;
+
+public enum MessageHeaderFlags {
+
+    TEXT(1),
+    RTF(1 << 1),
+    HTML(1 << 2),
+    DIB(1 << 3),
+    FILES(1 << 4),
+    CAPS(1 << 24),
+    REQUEST(1 << 25),
+    PEEK(1 << 26),
+    NOTIFY(1 << 27),
+    PROVIDE(1 << 28);
+
+    final int code;
+
+    MessageHeaderFlags(int code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/ServerCutText.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/ServerCutText.java
@@ -3,7 +3,12 @@ package com.shinyhut.vernacular.protocol.messages;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
 
 public class ServerCutText {
 
@@ -20,10 +25,53 @@ public class ServerCutText {
     public static ServerCutText decode(InputStream in) throws IOException {
         DataInputStream dataInput = new DataInputStream(in);
         dataInput.readFully(new byte[4]);
+
         int textLength = dataInput.readInt();
+
+        if (textLength < 0) {
+            return decodeExtendedMessageFormat(dataInput, -textLength);
+        }
+
+        return decodeOriginalFormat(dataInput, textLength);
+    }
+
+    private static ServerCutText decodeOriginalFormat(DataInputStream dataInput, Integer textLength) throws IOException {
         byte[] textBytes = new byte[textLength];
         dataInput.readFully(textBytes);
-        String text = new String(textBytes, Charset.forName("ISO-8859-1"));
+        String text = new String(textBytes, StandardCharsets.ISO_8859_1);
         return new ServerCutText(text);
     }
+
+    private static ServerCutText decodeExtendedMessageFormat(DataInputStream dataInput, Integer textLength) throws IOException {
+        Charset charset = StandardCharsets.UTF_8;
+
+        int flags = dataInput.readInt();
+
+        byte[] textBytes = new byte[textLength - 4];
+        dataInput.readFully(textBytes);
+
+        if ((flags & MessageHeaderFlags.CAPS.code) != 0) {
+            return new ServerCutText("");
+        }
+
+        if ((flags & MessageHeaderFlags.PROVIDE.code) != 0) {
+            Inflater inflater = new Inflater();
+
+            inflater.setInput(textBytes, 0, textBytes.length);
+            byte[] result = new byte[20 * 1024 * 1024];
+            try {
+                inflater.inflate(result);
+            } catch (DataFormatException e) {
+                throw new RuntimeException(e);
+            } finally {
+                inflater.end();
+            }
+            int length = new BigInteger(Arrays.copyOfRange(result, 0, 4)).intValue();
+            String text = new String(result, 4, length - 1, charset);
+            return new ServerCutText(text);
+        }
+
+        return new ServerCutText("");
+    }
+
 }

--- a/src/test/groovy/com/shinyhut/vernacular/protocol/messages/ClientCutTextExtendedClipboardTest.groovy
+++ b/src/test/groovy/com/shinyhut/vernacular/protocol/messages/ClientCutTextExtendedClipboardTest.groovy
@@ -1,0 +1,25 @@
+package com.shinyhut.vernacular.protocol.messages
+
+import spock.lang.Specification
+
+class ClientCutTextExtendedClipboardTest extends Specification {
+
+    def "should encode a valid ClientCutTextExtendedClipboard message"() {
+        given:
+        def message = new ClientCutTextExtendedClipboard('test')
+        def output = new ByteArrayOutputStream()
+
+        when:
+        message.encode(output)
+
+        then:
+        output.toByteArray() == [
+                0x06, // message type
+                0x00, 0x00, 0x00, // padding
+                -0x01, -0x01, -0x01, -0x15, // -1 * (compressed text length + U32 flags)
+                0x10, 0x00, 0x00, 0x01,  // flags
+                0x78, -0x64, 0x63, 0x60, 0x60, 0x60, 0x2d, 0x49, 0x2d, 0x2e, 0x61, 0x00, 0x00, 0x06, 0x40, 0x01, -0x3a // compressed text
+        ] as byte[]
+    }
+
+}

--- a/src/test/groovy/com/shinyhut/vernacular/protocol/messages/ServerCutTextTest.groovy
+++ b/src/test/groovy/com/shinyhut/vernacular/protocol/messages/ServerCutTextTest.groovy
@@ -20,4 +20,22 @@ class ServerCutTextTest extends Specification {
         then:
         result.text == 'test'
     }
+
+    def "should decode a valid ServerCutText extended format message"() {
+        given:
+        def input = new ByteArrayInputStream([
+                0x03, // message type
+                0x00, 0x00, 0x00, // padding
+                -0x01, -0x01, -0x01, -0x15, // data length = -21
+                0x10, 0x00, 0x00, 0x01,  // flags
+                0x78, -0x64, 0x63, 0x60, 0x60, 0x60, 0x2d, 0x49, 0x2d, 0x2e, 0x61, 0x00, 0x00, 0x06, 0x40, 0x01, -0x3a // compressed text
+
+        ] as byte[])
+
+        when:
+        def result = ServerCutText.decode(input)
+
+        then:
+        result.text == 'test'
+    }
 }


### PR DESCRIPTION
Added extended clipboard support for ClientCutText and ServerCutText.

Added ClientCutText caps message indicating we only support the provide operation, text format and our maximum text length, made it configurable -
https://github.com/shinyhut/vernacular-vnc/pull/28#issuecomment-1229456723