### PR TITLE
Fix colors, allow little endian encoding, fix packet fragmentation

### DIFF
--- a/src/main/java/com/shinyhut/vernacular/client/rendering/ColorDepth.java
+++ b/src/main/java/com/shinyhut/vernacular/client/rendering/ColorDepth.java
@@ -6,25 +6,39 @@ public enum ColorDepth {
     BPP_8_INDEXED(8, 8, false, 0, 0, 0, 0, 0, 0),
 
     /** 8 bits per pixel true color **/
-    BPP_8_TRUE(8, 8, true, 7, 3, 7, 0, 6, 3),
+    BPP_8_TRUE(8, 8, true, 7, 7, 3, 5, 2, 0),
+//    BPP_8_TRUE(8, 8, true, 7, 7, 3, 0, 3, 6),
 
-    /** 16 bits per pixel true color **/
+    /** 16 bits per pixel true color, RGB565 **/
     BPP_16_TRUE(16, 16, true, 31, 63, 31, 11, 5, 0),
 
-    /** 24 bits per pixel true color **/
-    BPP_24_TRUE(32, 24, true, 255, 255, 255, 8, 24, 16);
+    /** 24 bits per pixel true color, RGB888 **/
+    BPP_24_TRUE(32, 24, true, 255, 255, 255, 16, 8, 0);
 
     private final int bitsPerPixel;
     private final int depth;
     private final boolean trueColor;
     private final int redMax;
-    private final int blueMax;
     private final int greenMax;
+    private final int blueMax;
     private final int redShift;
-    private final int blueShift;
     private final int greenShift;
+    private final int blueShift;
 
-    ColorDepth(int bitsPerPixel, int depth, boolean trueColor, int redMax, int blueMax, int greenMax, int redShift, int blueShift, int greenShift) {
+    /**
+     * Create a ColorDepth object to track RGB elements of the connection
+     *
+     * @param bitsPerPixel Total bits per pixel
+     * @param depth Total bits responsible for color data
+     * @param trueColor Is true color and not indexed color
+     * @param redMax max value for red
+     * @param greenMax max value for green
+     * @param blueMax max value for blue
+     * @param redShift bit shift to get red out of presented data
+     * @param greenShift bit shift to get green out of presented data
+     * @param blueShift bit shift to get blue out of presented data
+     */
+    ColorDepth(int bitsPerPixel, int depth, boolean trueColor, int redMax, int greenMax, int blueMax, int redShift, int greenShift, int blueShift) {
         this.bitsPerPixel = bitsPerPixel;
         this.depth = depth;
         this.trueColor = trueColor;
@@ -52,23 +66,23 @@ public enum ColorDepth {
         return redMax;
     }
 
-    public int getBlueMax() {
-        return blueMax;
-    }
-
     public int getGreenMax() {
         return greenMax;
+    }
+
+    public int getBlueMax() {
+        return blueMax;
     }
 
     public int getRedShift() {
         return redShift;
     }
 
-    public int getBlueShift() {
-        return blueShift;
-    }
-
     public int getGreenShift() {
         return greenShift;
+    }
+
+    public int getBlueShift() {
+        return blueShift;
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/client/rendering/Framebuffer.java
+++ b/src/main/java/com/shinyhut/vernacular/client/rendering/Framebuffer.java
@@ -33,7 +33,7 @@ public class Framebuffer {
     private BufferedImage frame;
 
     public Framebuffer(VncSession session) {
-        PixelDecoder pixelDecoder = new PixelDecoder(colorMap);
+        PixelDecoder pixelDecoder = new PixelDecoder(colorMap, session.getPixelFormat().isBigEndian());
         RawRenderer rawRenderer = new RawRenderer(pixelDecoder, session.getPixelFormat());
         renderers.put(RAW, rawRenderer);
         renderers.put(COPYRECT, new CopyRectRenderer());

--- a/src/main/java/com/shinyhut/vernacular/client/rendering/renderers/PixelDecoder.java
+++ b/src/main/java/com/shinyhut/vernacular/client/rendering/renderers/PixelDecoder.java
@@ -13,18 +13,41 @@ public class PixelDecoder {
     private static final ColorMapEntry BLACK = new ColorMapEntry(0, 0, 0);
 
     private final Map<Long, ColorMapEntry> colorMap;
+    private final boolean isBigEndian;
 
-    public PixelDecoder(Map<Long, ColorMapEntry> colorMap) {
+    /**
+     * New Pixel decoder to read data offline from stream
+     *
+     * @param colorMap colorMap to match to
+     * @param isBigEndian if the data streaming in is big endian vs little for processing
+     */
+    public PixelDecoder(Map<Long, ColorMapEntry> colorMap, boolean isBigEndian) {
         this.colorMap = colorMap;
+        this.isBigEndian = isBigEndian;
     }
 
+    /**
+     * Each pixels data comes in here, and is converted to be ready to go to Java AWT
+     *
+     * @param in bit stream in
+     * @param pixelFormat format we are converting to
+     * @return return a Java Pixel
+     * @throws IOException exception if reading a byte array fails
+     */
     public Pixel decode(InputStream in, PixelFormat pixelFormat) throws IOException {
         int bytesToRead = pixelFormat.getBytesPerPixel();
         long value = 0L;
 
-        for (int i = 0; i < bytesToRead; i++) {
-            value <<= 8;
-            value |= in.read();
+        if (isBigEndian) {
+            for (int i = 0; i < bytesToRead; i++) {
+                value <<= 8;
+                value |= in.read();
+            }
+        } else {
+            // Read bytes in little-endian order
+            for (int i = 0; i < bytesToRead; i++) {
+                value |= ((long) in.read()) << (8 * i);
+            }
         }
 
         int red;

--- a/src/main/java/com/shinyhut/vernacular/protocol/initialization/Initializer.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/initialization/Initializer.java
@@ -43,7 +43,7 @@ public class Initializer {
         PixelFormat pixelFormat = new PixelFormat(
                 colorDepth.getBitsPerPixel(),
                 colorDepth.getDepth(),
-                true,
+                serverInit.getPixelFormat().isBigEndian(),
                 colorDepth.isTrueColor(),
                 colorDepth.getRedMax(),
                 colorDepth.getGreenMax(),

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/ClientCutText.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/ClientCutText.java
@@ -1,10 +1,8 @@
 package com.shinyhut.vernacular.protocol.messages;
 
-import java.io.DataOutput;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class ClientCutText implements Encodable {
 
@@ -20,10 +18,23 @@ public class ClientCutText implements Encodable {
 
     @Override
     public void encode(OutputStream out) throws IOException {
-        DataOutput dataOutput = new DataOutputStream(out);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dataOutput = new DataOutputStream(baos);
+
         dataOutput.writeByte(0x06);
         dataOutput.write(new byte[3]);
         dataOutput.writeInt(text.length());
-        dataOutput.write(text.getBytes(Charset.forName("ISO-8859-1")));
+        dataOutput.write(text.getBytes(StandardCharsets.ISO_8859_1));
+        dataOutput.flush(); // Ensure all data is written to the ByteArrayOutputStream
+
+        byte[] bytes = baos.toByteArray();
+        out.write(bytes);   // Send all bytes at once
+        out.flush();        // Ensure the data is sent immediately
+
+//        DataOutput dataOutput = new DataOutputStream(out);
+//        dataOutput.writeByte(0x06);
+//        dataOutput.write(new byte[3]);
+//        dataOutput.writeInt(text.length());
+//        dataOutput.write(text.getBytes(StandardCharsets.ISO_8859_1));
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/ClientCutText.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/ClientCutText.java
@@ -30,11 +30,5 @@ public class ClientCutText implements Encodable {
         byte[] bytes = baos.toByteArray();
         out.write(bytes);   // Send all bytes at once
         out.flush();        // Ensure the data is sent immediately
-
-//        DataOutput dataOutput = new DataOutputStream(out);
-//        dataOutput.writeByte(0x06);
-//        dataOutput.write(new byte[3]);
-//        dataOutput.writeInt(text.length());
-//        dataOutput.write(text.getBytes(StandardCharsets.ISO_8859_1));
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/ErrorMessage.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/ErrorMessage.java
@@ -4,6 +4,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class ErrorMessage {
 
@@ -22,7 +23,7 @@ public class ErrorMessage {
         int errorMessageLength = dataInput.readInt();
         byte[] errorMessageBytes = new byte[errorMessageLength];
         dataInput.readFully(errorMessageBytes);
-        return new ErrorMessage(new String(errorMessageBytes, Charset.forName("US-ASCII")));
+        return new ErrorMessage(new String(errorMessageBytes, StandardCharsets.US_ASCII));
     }
 
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/FramebufferUpdateRequest.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/FramebufferUpdateRequest.java
@@ -34,13 +34,5 @@ public class FramebufferUpdateRequest implements Encodable {
         byte[] bytes = baos.toByteArray();
         out.write(bytes);   // Send all bytes at once
         out.flush();        // Ensure the data is sent immediately
-
-//        DataOutput dataOutput = new DataOutputStream(out);
-//        dataOutput.writeByte(0x03);
-//        dataOutput.writeBoolean(incremental);
-//        dataOutput.writeShort(x);
-//        dataOutput.writeShort(y);
-//        dataOutput.writeShort(width);
-//        dataOutput.writeShort(height);
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/FramebufferUpdateRequest.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/FramebufferUpdateRequest.java
@@ -1,9 +1,6 @@
 package com.shinyhut.vernacular.protocol.messages;
 
-import java.io.DataOutput;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 
 public class FramebufferUpdateRequest implements Encodable {
 
@@ -23,12 +20,27 @@ public class FramebufferUpdateRequest implements Encodable {
 
     @Override
     public void encode(OutputStream out) throws IOException {
-        DataOutput dataOutput = new DataOutputStream(out);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dataOutput = new DataOutputStream(baos);
+
         dataOutput.writeByte(0x03);
         dataOutput.writeBoolean(incremental);
         dataOutput.writeShort(x);
         dataOutput.writeShort(y);
         dataOutput.writeShort(width);
         dataOutput.writeShort(height);
+        dataOutput.flush(); // Ensure all data is written to the ByteArrayOutputStream
+
+        byte[] bytes = baos.toByteArray();
+        out.write(bytes);   // Send all bytes at once
+        out.flush();        // Ensure the data is sent immediately
+
+//        DataOutput dataOutput = new DataOutputStream(out);
+//        dataOutput.writeByte(0x03);
+//        dataOutput.writeBoolean(incremental);
+//        dataOutput.writeShort(x);
+//        dataOutput.writeShort(y);
+//        dataOutput.writeShort(width);
+//        dataOutput.writeShort(height);
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/KeyEvent.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/KeyEvent.java
@@ -1,9 +1,6 @@
 package com.shinyhut.vernacular.protocol.messages;
 
-import java.io.DataOutput;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 
 public class KeyEvent implements Encodable {
 
@@ -17,10 +14,24 @@ public class KeyEvent implements Encodable {
 
     @Override
     public void encode(OutputStream out) throws IOException {
-        DataOutput dataOutput = new DataOutputStream(out);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dataOutput = new DataOutputStream(baos);
+
         dataOutput.writeByte(0x04);
         dataOutput.writeBoolean(pressed);
         dataOutput.write(new byte[]{0x00, 0x00});
         dataOutput.writeInt(keysym);
+        dataOutput.flush(); // Ensure all data is written to the ByteArrayOutputStream
+
+        byte[] bytes = baos.toByteArray();
+        out.write(bytes);   // Send all bytes at once
+        out.flush();        // Ensure the data is sent immediately
+
+
+//        DataOutput dataOutput = new DataOutputStream(out);
+//        dataOutput.writeByte(0x04);
+//        dataOutput.writeBoolean(pressed);
+//        dataOutput.write(new byte[]{0x00, 0x00});
+//        dataOutput.writeInt(keysym);
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/KeyEvent.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/KeyEvent.java
@@ -26,12 +26,5 @@ public class KeyEvent implements Encodable {
         byte[] bytes = baos.toByteArray();
         out.write(bytes);   // Send all bytes at once
         out.flush();        // Ensure the data is sent immediately
-
-
-//        DataOutput dataOutput = new DataOutputStream(out);
-//        dataOutput.writeByte(0x04);
-//        dataOutput.writeBoolean(pressed);
-//        dataOutput.write(new byte[]{0x00, 0x00});
-//        dataOutput.writeInt(keysym);
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/PointerEvent.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/PointerEvent.java
@@ -29,12 +29,6 @@ public class PointerEvent implements Encodable {
         byte[] bytes = baos.toByteArray();
         out.write(bytes);   // Send all bytes at once
         out.flush();        // Ensure the data is sent immediately
-
-//        DataOutput dataOutput = new DataOutputStream(out);
-//        dataOutput.write(0x05);
-//        dataOutput.write(buttonMask());
-//        dataOutput.writeShort(x);
-//        dataOutput.writeShort(y);
     }
 
     private byte buttonMask() {

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/PointerEvent.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/PointerEvent.java
@@ -1,9 +1,6 @@
 package com.shinyhut.vernacular.protocol.messages;
 
-import java.io.DataOutput;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.List;
 
 public class PointerEvent implements Encodable {
@@ -20,11 +17,24 @@ public class PointerEvent implements Encodable {
 
     @Override
     public void encode(OutputStream out) throws IOException {
-        DataOutput dataOutput = new DataOutputStream(out);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dataOutput = new DataOutputStream(baos);
+
         dataOutput.write(0x05);
         dataOutput.write(buttonMask());
         dataOutput.writeShort(x);
         dataOutput.writeShort(y);
+        dataOutput.flush(); // Ensure all data is written to the ByteArrayOutputStream
+
+        byte[] bytes = baos.toByteArray();
+        out.write(bytes);   // Send all bytes at once
+        out.flush();        // Ensure the data is sent immediately
+
+//        DataOutput dataOutput = new DataOutputStream(out);
+//        dataOutput.write(0x05);
+//        dataOutput.write(buttonMask());
+//        dataOutput.writeShort(x);
+//        dataOutput.writeShort(y);
     }
 
     private byte buttonMask() {

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/ProtocolVersion.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/ProtocolVersion.java
@@ -5,6 +5,7 @@ import com.shinyhut.vernacular.client.exceptions.VncException;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,7 +34,7 @@ public class ProtocolVersion implements Encodable {
 
     @Override
     public void encode(OutputStream out) throws IOException {
-        out.write(format("RFB %03d.%03d\n", major, minor).getBytes(Charset.forName("US-ASCII")));
+        out.write(format("RFB %03d.%03d\n", major, minor).getBytes(StandardCharsets.US_ASCII));
     }
 
     public boolean equals(int major, int minor) {

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/ServerInit.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/ServerInit.java
@@ -4,6 +4,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class ServerInit {
 
@@ -43,7 +44,7 @@ public class ServerInit {
         int nameLength = dataInput.readInt();
         byte[] nameBytes = new byte[nameLength];
         dataInput.readFully(nameBytes);
-        String name = new String(nameBytes, Charset.forName("US-ASCII"));
+        String name = new String(nameBytes, StandardCharsets.US_ASCII);
         return new ServerInit(framebufferWidth, framebufferHeight, pixelFormat, name);
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/SetEncodings.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/SetEncodings.java
@@ -1,5 +1,6 @@
 package com.shinyhut.vernacular.protocol.messages;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -21,13 +22,20 @@ public class SetEncodings implements Encodable {
 
     @Override
     public void encode(OutputStream out) throws IOException {
-        DataOutputStream dataOutput = new DataOutputStream(out);
+        // DataOutputStream is acting weird and breaking into different packets
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dataOutput = new DataOutputStream(baos);
+
         dataOutput.writeByte(0x02);
         dataOutput.writeByte(0x00);
         dataOutput.writeShort(encodings.size());
         for (Encoding encoding : encodings) {
             dataOutput.writeInt(encoding.getCode());
         }
+        dataOutput.flush(); // Ensure all data is written to the ByteArrayOutputStream
 
+        byte[] bytes = baos.toByteArray();
+        out.write(bytes);   // Send all bytes at once
+        out.flush();        // Ensure the data is sent immediately
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/SetPixelFormat.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/SetPixelFormat.java
@@ -1,5 +1,7 @@
 package com.shinyhut.vernacular.protocol.messages;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -13,8 +15,22 @@ public class SetPixelFormat implements Encodable {
 
     @Override
     public void encode(OutputStream out) throws IOException {
-        out.write(0x00);
-        out.write(new byte[3]);
-        pixelFormat.encode(out);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dataOutput = new DataOutputStream(baos);
+
+        dataOutput.writeByte(0x00);
+        dataOutput.writeByte(0x00);
+        dataOutput.writeByte(0x00);
+        dataOutput.writeByte(0x00);
+        pixelFormat.encode(dataOutput);
+        dataOutput.flush(); // Ensure all data is written to the ByteArrayOutputStream
+
+        byte[] bytes = baos.toByteArray();
+        out.write(bytes);   // Send all bytes at once
+        out.flush();        // Ensure the data is sent immediately
+
+//        out.write(0x00);
+//        out.write(new byte[3]);
+//        pixelFormat.encode(out);
     }
 }

--- a/src/main/java/com/shinyhut/vernacular/protocol/messages/SetPixelFormat.java
+++ b/src/main/java/com/shinyhut/vernacular/protocol/messages/SetPixelFormat.java
@@ -28,9 +28,5 @@ public class SetPixelFormat implements Encodable {
         byte[] bytes = baos.toByteArray();
         out.write(bytes);   // Send all bytes at once
         out.flush();        // Ensure the data is sent immediately
-
-//        out.write(0x00);
-//        out.write(new byte[3]);
-//        pixelFormat.encode(out);
     }
 }


### PR DESCRIPTION
Worked on several issues that appear to be working better:
- The ColorDepth class was taking (...RED, BLUE, GREEN...) instead of the standard RGB, and the Initializer was using RGB sequence, leading to odd color settings, fixed that and documented more
- The library was hard coded to Big Endian encoding and I needed little, I have the client now check what the server is setting and adjust as needed
- With the DataOutputs getting bytes written directly to them, at times the packets would fragment, now sending as one array

I tested on Vmware Fusion VNC Server, and Gnome Remote Desktop Server. Let me know if you want any changes or more info. Happy to help, and thank you for the great work on this library!